### PR TITLE
Coloured results and CommandLineResult class

### DIFF
--- a/src/PipelineTasks/ApiCompat/source/commandLineResult.ts
+++ b/src/PipelineTasks/ApiCompat/source/commandLineResult.ts
@@ -8,6 +8,6 @@ export default class CommandLineResult {
     }
 
     private parseMessage(message: string): number {
-        return Number((message.split(':'))[1].trim());
+        return parseInt((message.split(':'))[1].trim(), 10);
     }
 }

--- a/src/PipelineTasks/ApiCompat/source/commandLineResult.ts
+++ b/src/PipelineTasks/ApiCompat/source/commandLineResult.ts
@@ -8,6 +8,6 @@ export default class CommandLineResult {
     }
 
     private parseMessage(message: string): number {
-        return parseInt((message.split(':'))[1].trim(), 10);
+        return parseInt(message.split(':')[1].trim(), 10);
     }
 }

--- a/src/PipelineTasks/ApiCompat/source/commandLineResult.ts
+++ b/src/PipelineTasks/ApiCompat/source/commandLineResult.ts
@@ -1,0 +1,13 @@
+export default class CommandLineResult {
+    totalIssues: number;
+    body: string;
+
+    constructor( totalIssuesMessage: string, body: string,) {
+        this.totalIssues = this.parseMessage(totalIssuesMessage);
+        this.body = body;
+    }
+
+    private parseMessage(message: string): number {
+        return Number((message.split(':'))[1].trim());
+    }
+}

--- a/src/PipelineTasks/ApiCompat/source/commandLineResult.ts
+++ b/src/PipelineTasks/ApiCompat/source/commandLineResult.ts
@@ -2,7 +2,7 @@ export default class CommandLineResult {
     totalIssues: number;
     body: string;
 
-    constructor( totalIssuesMessage: string, body: string,) {
+    constructor( body: string, totalIssuesMessage: string) {
         this.totalIssues = this.parseMessage(totalIssuesMessage);
         this.body = body;
     }

--- a/src/PipelineTasks/ApiCompat/source/core.ts
+++ b/src/PipelineTasks/ApiCompat/source/core.ts
@@ -47,13 +47,15 @@ export class Core {
     public runWithCustomError(command: string): void{
         command = this.addOptions(command);
         try {
-            const result = execSync(command).toString();
+            const result: string[] = this.parseResult(execSync(command).toString());
 
-            if (this.parseMessage(result)) {
-                console.log(result);
+            if (this.parseMessage(result.filter(r => r.includes("Total Issues")).toString())) {
+                console.log(result[0]);
+                console.log(result[1],"Green");
             }
             else {
-                console.log(result);
+                console.log(result[0]);
+                console.log(result[1],"Red");
                 this.LogError(`There were differences between the assemblies`)
             }
         }
@@ -72,6 +74,14 @@ export class Core {
         command += warnOnMissingAssemblies? ' --warn-on-missing-assemblies' : '';
 
         return command;
+    }
+
+    public parseResult(message: string): string[] {
+        const indexOfResult: number = message.indexOf("Total Issues");
+        const body: string = message.substring(0, indexOfResult-1);
+        const result: string = message.substring(indexOfResult, message.length); 
+        
+        return [body, result];
     }
 
     private LogError(message: string): void {

--- a/src/PipelineTasks/ApiCompat/source/index.ts
+++ b/src/PipelineTasks/ApiCompat/source/index.ts
@@ -37,7 +37,7 @@ function runWithWarning(command: string): void {
     let result = parseResult(execSync(command).toString());
 
     console.log(result.body);
-    console.log("\x1b[33m",result.totalIssues);
+    console.log("\x1b[33m", "Total Issues : " + result.totalIssues);
     setResult(TaskResult.SucceededWithIssues, `There were ${ result.totalIssues } differences between the assemblies`);}
 
 function runWithError(command: string): void {
@@ -49,11 +49,11 @@ function runWithError(command: string): void {
 
         if (result.totalIssues > 0) {
             console.log(result.body);
-            console.log("\x1b[31m", result.totalIssues);
+            console.log("\x1b[31m", "Total Issues : " + result.totalIssues);
             setResult(TaskResult.Failed, `There were ${result} differences between the assemblies`);
         } else {
             console.log(result.body);
-            console.log("\x1b[32m", result.totalIssues);
+            console.log("\x1b[32m", "Total Issues : " +  result.totalIssues);
             setResult(TaskResult.Succeeded, `There were no differences between the assemblies`);
         }
     } catch (error) {
@@ -71,6 +71,8 @@ function addOptions(command: string): string {
 
 function parseResult(message: string): CommandLineResult {
     const indexOfResult: number = message.indexOf("Total Issues");
-    return new CommandLineResult(message.substring(0, indexOfResult - 1),
-        message.substring(indexOfResult));
+    const a = new CommandLineResult(message.substring(0, indexOfResult - 1),
+    message.substring(indexOfResult));
+    console.log( a );
+    return a;
 }

--- a/src/PipelineTasks/ApiCompat/source/index.ts
+++ b/src/PipelineTasks/ApiCompat/source/index.ts
@@ -35,10 +35,16 @@ function getInputFiles(): string {
 
 function runWithWarning(command: string): void {
     let result = parseResult(execSync(command).toString());
-
-    console.log(result.body);
-    console.log("\x1b[33m", "Total Issues : " + result.totalIssues);
-    setResult(TaskResult.SucceededWithIssues, `There were ${ result.totalIssues } differences between the assemblies`);}
+    if (result.totalIssues > 0) {
+            console.log(result.body);
+            console.log("\x1b[33m", "Total Issues : " + result.totalIssues);
+            setResult(TaskResult.SucceededWithIssues, `There were ${ result.totalIssues } differences between the assemblies`);
+    } else {
+        console.log(result.body);
+        console.log("\x1b[32m", "Total Issues : " +  result.totalIssues);
+        setResult(TaskResult.Succeeded, `There were no differences between the assemblies`);
+    }
+}
 
 function runWithError(command: string): void {
     let result: CommandLineResult;

--- a/src/PipelineTasks/ApiCompat/source/index.ts
+++ b/src/PipelineTasks/ApiCompat/source/index.ts
@@ -34,8 +34,11 @@ function getInputFiles(): string {
 }
 
 function runWithWarning(command: string): void {
-    console.log(execSync(command).toString());
-}
+    let result = parseResult(execSync(command).toString());
+
+    console.log(result.body);
+    console.log("\x1b[33m",result.totalIssues);
+    setResult(TaskResult.SucceededWithIssues, `There were ${ result.totalIssues } differences between the assemblies`);}
 
 function runWithError(command: string): void {
     let result: CommandLineResult;
@@ -46,11 +49,11 @@ function runWithError(command: string): void {
 
         if (result.totalIssues > 0) {
             console.log(result.body);
-            console.log(result.totalIssues, "Red");
+            console.log("\x1b[31m", result.totalIssues);
             setResult(TaskResult.Failed, `There were ${result} differences between the assemblies`);
         } else {
             console.log(result.body);
-            console.log(result.totalIssues, "Green");
+            console.log("\x1b[32m", result.totalIssues);
             setResult(TaskResult.Succeeded, `There were no differences between the assemblies`);
         }
     } catch (error) {
@@ -69,5 +72,5 @@ function addOptions(command: string): string {
 function parseResult(message: string): CommandLineResult {
     const indexOfResult: number = message.indexOf("Total Issues");
     return new CommandLineResult(message.substring(0, indexOfResult - 1),
-        message.substring(indexOfResult, message.length));
+        message.substring(indexOfResult));
 }

--- a/src/PipelineTasks/ApiCompat/source/index.ts
+++ b/src/PipelineTasks/ApiCompat/source/index.ts
@@ -71,8 +71,6 @@ function addOptions(command: string): string {
 
 function parseResult(message: string): CommandLineResult {
     const indexOfResult: number = message.indexOf("Total Issues");
-    const a = new CommandLineResult(message.substring(0, indexOfResult - 1),
+    return new CommandLineResult(message.substring(0, indexOfResult - 1),
     message.substring(indexOfResult));
-    console.log( a );
-    return a;
 }

--- a/src/PipelineTasks/ApiCompat/source/index.ts
+++ b/src/PipelineTasks/ApiCompat/source/index.ts
@@ -14,9 +14,9 @@ function run(): void {
     const command = `"${ApiCompatPath}" "${inputFiles}" --impl-dirs "${getInput('implFolder')}"`;
 
     if (getInput('failOnIssue') === 'true') {
-        console.log(runWithError(command));
+        runWithError(command);
     } else {
-        console.log(runWithWarning(command));
+        runWithWarning(command);
     }
 }
 


### PR DESCRIPTION
- `runPlain` rename to `runWithWarning`
- `runWithWarning` type went from `string` to `void`
- Add class `CommandLineResult` to handle the output of running the command
- `parseMessage` method now belongs to `CommandLineResult` 